### PR TITLE
Add arithmetic to length units

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ install:
  - "pip install -e .[test]"
 script:
  - "flake8 ."
- - "pytest"
+ - "py.test"  # the dot is for 3.3 compatibility

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,8 @@ setup(
     license='',
     install_requires=[
         'lxml'
-    ]
+    ],
+    extras_require={
+        'test': ['pytest']
+    }
 )

--- a/svgast/units.py
+++ b/svgast/units.py
@@ -1,4 +1,4 @@
-from numbers import Complex
+from numbers import Number
 
 
 class Length:
@@ -10,7 +10,7 @@ class Length:
     def __init__(self, length):
         if isinstance(length, Length):
             self.px = length.px
-        elif isinstance(length, Complex):
+        elif isinstance(length, Number):
             # Any numerical value:
             self.px = length * self._px_per_unit
         else:
@@ -56,13 +56,13 @@ class Length:
         return user(other - self.px)
 
     def __mul__(self, other):
-        if isinstance(other, Complex):
+        if isinstance(other, Number):
             return type(self)(user(self.px * other))
         else:
             raise TypeError()
 
     def __rmul__(self, other):
-        if isinstance(other, Complex):
+        if isinstance(other, Number):
             return type(self)(user(other * self.px))
         else:
             raise TypeError()

--- a/svgast/units.py
+++ b/svgast/units.py
@@ -22,6 +22,66 @@ class Length:
             str_number(self.px / self._px_per_unit),
             self.unit)
 
+    def __abs__(self):
+        return self.px
+
+    def __add__(self, other):
+        if isinstance(other, Length):
+            px = self.px + other.px
+        else:
+            px = self.px + other
+        l = user(px)
+        if type(self) is type(other):
+            return type(self)(l)
+        else:
+            return l
+
+    def __radd__(self, other):
+        assert not isinstance(other, Length)
+        return user(other + self.px)
+
+    def __sub__(self, other):
+        if isinstance(other, Length):
+            px = self.px - other.px
+        else:
+            px = self.px - other
+        l = user(px)
+        if type(self) is type(other):
+            return type(self)(l)
+        else:
+            return l
+
+    def __rsub__(self, other):
+        assert not isinstance(other, Length)
+        return user(other - self.px)
+
+    def __mul__(self, other):
+        if isinstance(other, Complex):
+            return type(self)(user(self.px * other))
+        else:
+            raise TypeError()
+
+    def __rmul__(self, other):
+        if isinstance(other, Complex):
+            return type(self)(user(other * self.px))
+        else:
+            raise TypeError()
+
+    def __truediv__(self, other):
+        if isinstance(other, Length):
+            return user(self.px / other.px)
+        else:
+            return type(self)(user(self.px / other))
+
+    def __neg__(self):
+        return type(self)(user(-self.px))
+
+    def __eq__(self, other):
+        if isinstance(other, Length):
+            return self.px == other.px
+        else:
+            return self.px == other
+
 
 class user(Length):
     unit = ''

--- a/test/test_units.py
+++ b/test/test_units.py
@@ -1,0 +1,94 @@
+from pytest import raises
+
+from svgast.units import mm, cm, in_, px, pt, pc, user
+
+
+def test_str():
+    assert str(mm(42)) == '42mm'
+    assert str(user(42)) == '42'
+
+
+def test_eq():
+    assert in_(1) == 90
+    assert px(42) == user(42)
+    assert mm(10) == cm(1)
+
+
+def test_neq():
+    assert mm(10) != px(10)
+
+
+def test_abs():
+    assert abs(pc(1)) == 15
+
+
+def test_add_same_type():
+    result = mm(23) + mm(19)
+    assert result == mm(42)
+    assert isinstance(result, mm)
+
+
+def test_add_different_type():
+    result = in_(2) + px(-138)
+    assert result == px(42)
+    assert isinstance(result, user)
+
+
+def test_add_unitless():
+    result = in_(2) + 90
+    assert result == in_(3)
+    assert isinstance(result, user)
+
+
+def test_radd_unitless():
+    result = 90 + in_(2)
+    assert result == in_(3)
+    assert isinstance(result, user)
+
+
+def test_sub_same_type():
+    result = in_(84) - in_(42)
+    assert result == in_(42)
+    assert isinstance(result, in_)
+
+
+def test_sub_different_type():
+    result = in_(1) - px(48)
+    assert result == user(42)
+    assert isinstance(result, user)
+
+
+def test_sub_unitless():
+    result = pc(3) - 3
+    assert result == 42
+    assert isinstance(result, user)
+
+
+def test_rsub_unitless():
+    result = 222 - in_(2)
+    assert result == 42
+    assert isinstance(result, user)
+
+
+def test_mul():
+    for a, b in [(1.5, mm(30)), (mm(30), 1.5)]:
+        result = a * b
+        assert result == mm(45)
+        assert isinstance(result, mm)
+    with raises(TypeError):
+        mm(30) * mm(12)
+
+
+def test_div():
+    result = pt(8) / 2
+    assert result == px(5)
+    assert isinstance(result, pt)
+    result = mm(30) / cm(3)
+    assert result == 1
+    assert isinstance(result, user)
+    with raises(TypeError):
+        3 / mm(30)
+
+
+def test_neg():
+    assert -mm(30) == mm(-30)


### PR DESCRIPTION
I wanted to be able to add some lengths together without understanding the underlying canonical "user" unit. For example, if I want to specify something as being 3 mm left of a particular x coordinate (say 88 mm), I can write `mm(88) - mm(4)` and get `mm(84)`. We cast to "unitless" user units in the case where you mix unit types. I implemented scalar multiplication and division in a way I hope is sensible. Please pick holes.