### PR TITLE
Up test coverage to 100%

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
 script:
  - "flake8 ."
    # the dot is for 3.3 compatibility:
- - "py.test --cov=svgast --cov-report=term-missing"
+ - "py.test --cov=svgast --cov-report=term-missing --cov-branch --cov-fail-under=100"

--- a/src/svgast/ast.py
+++ b/src/svgast/ast.py
@@ -2,7 +2,7 @@ import sys
 from collections import namedtuple
 from functools import partial, wraps
 
-from .units import to_length, str_number
+from .units import to_length
 
 _module = sys.modules[__name__]
 
@@ -94,16 +94,14 @@ class Use(Element):
 
 
 def _str_ins(ins):
-    if ins is z:
-        return 'Z'
-    else:
-        d = ins.__dict__
-        rel = d.pop('rel')
-        letter = ins.letter.lower() if rel else ins.letter.upper()
-        args = ' '.join(map(str, map(str_number, d.values())))
-        return '{} {}'.format(letter, args)
+    d = ins.__dict__
+    rel = d.pop('rel')
+    letter = ins.letter.lower() if rel else ins.letter.upper()
+    args = ' '.join(map(str, map(to_length, d.values())))
+    return '{} {}'.format(letter, args)
 
 
+# FIXME: would like to validate arguements as lengths at construction time
 MoveTo = namedtuple('MoveTo', ('x', 'y', 'rel'))
 MoveTo.letter = 'm'
 MoveTo.__str__ = _str_ins
@@ -128,7 +126,7 @@ ArcTo.__str__ = _str_ins
 ClosePath = namedtuple('ClosePath', ())
 ClosePath.letter = 'z'
 ClosePath.__str__ = lambda _: 'Z'
-ClosePath.__call__ = lambda: z
+ClosePath.__call__ = lambda _: z
 z = ClosePath()
 Z = z
 
@@ -159,7 +157,7 @@ class ViewBox(namedtuple('ViewBox', ('ox', 'oy', 'width', 'height'))):
 
 class Kern(tuple):
     def __new__(cls, *args):
-        return super().__new__(cls, *map(to_length, args))
+        return super().__new__(cls, map(to_length, args))
 
     def __str__(self):
         return ' '.join(map(str, self))

--- a/src/svgast/ast.py
+++ b/src/svgast/ast.py
@@ -94,10 +94,9 @@ class Use(Element):
 
 
 def _str_ins(ins):
-    d = ins.__dict__
-    rel = d.pop('rel')
+    *values, rel = ins
     letter = ins.letter.lower() if rel else ins.letter.upper()
-    args = ' '.join(map(str, map(to_length, d.values())))
+    args = ' '.join(map(str, map(to_length, values)))
     return '{} {}'.format(letter, args)
 
 

--- a/src/svgast/units.py
+++ b/src/svgast/units.py
@@ -59,13 +59,13 @@ class Length:
         if isinstance(other, Number):
             return type(self)(user(self.px * other))
         else:
-            raise TypeError()
+            return NotImplemented
 
     def __rmul__(self, other):
         if isinstance(other, Number):
             return type(self)(user(other * self.px))
         else:
-            raise TypeError()
+            return NotImplemented
 
     def __truediv__(self, other):
         if isinstance(other, Length):

--- a/test/test_ast.py
+++ b/test/test_ast.py
@@ -1,0 +1,37 @@
+from svgast.ast import Svg, Rect, Circle, Path, M, l, z, Text
+from svgast.units import mm
+
+
+def test_view_box():
+    svg = Svg(viewBox=(0, mm(1), 10, 11))
+    assert svg.viewBox.ox == 0
+    assert svg.viewBox.oy == mm(1)
+    assert svg.viewBox.width == 10
+    assert svg.viewBox.height == 11
+    assert str(svg.viewBox) == '0 1mm 10 11'
+
+
+def test_element_getitem():
+    c = Circle()
+    svg = Svg(Rect(), c, Circle())
+    assert svg[1] is c
+
+
+def test_path():
+    p = Path(d=(M(0, 0), l(1, 0), l(0, mm(1)), z))
+    assert p.d[0].x == 0
+    assert p.d[0].rel is False
+    assert p.d[2].y == mm(1)
+    assert p.d[2].rel is True
+    assert p.d[3] is z
+    assert str(p.d) == 'M 0 0  l 1 0  l 0 1mm  Z'
+
+
+def test_text():
+    t = Text(dx=(1, 2, mm(3), 4))
+    assert t.dx[0] == 1
+    assert str(t.dx) == '1 2 3mm 4'
+
+
+def test_z():
+    assert z() is z

--- a/test/test_shapes.py
+++ b/test/test_shapes.py
@@ -1,0 +1,13 @@
+from svgast.shapes import square, circle
+
+# FIXME: these tests only really check the code executes
+
+
+def test_square():
+    square(5)
+    square(1, x=2, y=3, anticlockwise=True)
+
+
+def test_circle():
+    circle(3)
+    circle(5, cx=7, cy=9, anticlockwise=True)

--- a/test/test_units.py
+++ b/test/test_units.py
@@ -3,6 +3,10 @@ from pytest import raises
 from svgast.units import mm, cm, in_, px, pt, pc, user
 
 
+def test_bad_type():
+    raises(TypeError, mm, 'hello')
+
+
 def test_str():
     assert str(mm(42)) == '42mm'
     assert str(user(42)) == '42'
@@ -77,6 +81,8 @@ def test_mul():
         assert isinstance(result, mm)
     with raises(TypeError):
         mm(30) * mm(12)
+    with raises(TypeError):
+        'hello' * mm(30)
 
 
 def test_div():


### PR DESCRIPTION
Fixing two minor bugs
 - Text dx/Kern wasn't passing arguments correctly to tuple in super() call
 - Lengths (e.g. mm) weren't being properly converted when str()ing PathDs

We now enforce coverage stays at 100%